### PR TITLE
feat: JWT認証ミドルウェアの実装

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -64,6 +64,7 @@ func main() {
 
 	// initialize middlewares
 	tripOwnershipMiddleware := middleware.TripOwnershipMiddleware(tripUsecase)
+	authMiddleware := middleware.AuthMiddleware(jwtSecret)
 
 	// start Echo server
 	e := echo.New()
@@ -85,7 +86,8 @@ func main() {
 	e.DELETE("/public/trips/:shareToken/schedules/:scheduleId", wrapper.DeleteScheduleForPublicTrip)
 
 	// Auth-required routes
-	authRequired := e.Group("", authMiddleware)
+	authRequired := e.Group("")
+	authRequired.Use(authMiddleware)
 	authRequired.POST("/logout", wrapper.LogoutUser)
 	authRequired.GET("/me", wrapper.GetMe)
 	authRequired.PUT("/me/password", wrapper.ChangePassword)

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo v3.3.10+incompatible
+	github.com/labstack/echo-jwt/v4 v4.3.1
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/oapi-codegen/runtime v1.1.2
 	golang.org/x/crypto v0.38.0
@@ -39,5 +40,6 @@ require (
 	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
+	golang.org/x/time v0.11.0 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwA
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
+github.com/labstack/echo-jwt/v4 v4.3.1 h1:d8+/qf8nx7RxeL46LtoIwHJsH2PNN8xXCQ/jDianycE=
+github.com/labstack/echo-jwt/v4 v4.3.1/go.mod h1:yJi83kN8S/5vePVPd+7ID75P4PqPNVRs2HVeuvYJH00=
 github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcXEA=
 github.com/labstack/echo/v4 v4.13.4/go.mod h1:g63b33BZ5vZzcIUF8AtRH40DrTlXnx4UMC8rBdndmjQ=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
@@ -76,6 +78,8 @@ golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
 golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
+golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
+golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"trip_app/internal/security"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	echojwt "github.com/labstack/echo-jwt/v4"
+	"github.com/labstack/echo/v4"
+)
+
+// JWTトークンを検証し、ユーザーIDをコンテキストに設定するEchoミドルウェアを生成
+func AuthMiddleware(secret string) echo.MiddlewareFunc {
+	return echojwt.WithConfig(echojwt.Config{
+		// JWT トークンの署名に使用するキー
+		SigningKey: []byte(secret),
+		// Claims の型を指定
+		NewClaimsFunc: func(c echo.Context) jwt.Claims {
+			return new(security.JwtCustomClaims)
+		},
+		// SuccessHandlerはトークンが有効な場合に呼び出される関数
+		// トークンからユーザーIDを抽出してコンテキストに保存
+		SuccessHandler: func(c echo.Context) {
+			if user, ok := c.Get("user").(*jwt.Token); ok {
+				if claims, ok := user.Claims.(*security.JwtCustomClaims); ok {
+					userID := claims.UserID
+					parsedUserID, err := uuid.Parse(userID)
+					if err == nil {
+						c.Set("user_id", parsedUserID)
+					}
+				}
+			}
+		},
+	})
+}


### PR DESCRIPTION
APIエンドポイントを保護するためのJWT認証ミドルウェアを導入

- [x] securityにJwtCustomClaims構造体を定義し、トークン生成処理をリファクタリング
- [x] auth.goにJWTの検証とコンテキストへのユーザーID設定を行うミドルウェアを実装
- [x] main.goで認証が必要なルートグループにミドルウェアを適用